### PR TITLE
Set up pytest framework and initial test suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,13 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts =
+    -v
+    --tb=short
+    -m "not integration"
+    --strict-markers
+markers =
+    integration: tests requiring live API key and network access (deselected by default)
+    slow: tests that take more than a few seconds to run

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ matplotlib==3.7.2
 seaborn==0.12.2
 schedule==1.2.0
 python-dotenv==1.0.0
+
+# Testing
+pytest==7.4.0
+pytest-cov==4.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,136 @@
+"""
+Shared pytest fixtures for weather data pipeline tests.
+"""
+
+import pytest
+import numpy as np
+import pandas as pd
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+from configs.config import WeatherConfig
+from src.data_collection.weather_collector import WeatherCollector
+from src.data_collection.weather_collector import WeatherConfig as CollectorWeatherConfig
+
+
+@pytest.fixture
+def sample_raw_api_response():
+    """Dict mimicking a raw OpenWeatherMap API JSON response."""
+    return {
+        "coord": {"lon": -74.006, "lat": 40.7143},
+        "weather": [
+            {
+                "id": 800,
+                "main": "Clear",
+                "description": "clear sky",
+                "icon": "01d",
+            }
+        ],
+        "base": "stations",
+        "main": {
+            "temp": 22.5,
+            "feels_like": 21.8,
+            "temp_min": 20.0,
+            "temp_max": 25.0,
+            "pressure": 1013,
+            "humidity": 65,
+        },
+        "visibility": 10000,
+        "wind": {"speed": 3.5, "deg": 180},
+        "clouds": {"all": 10},
+        "dt": 1700000000,
+        "sys": {
+            "type": 2,
+            "id": 2039034,
+            "country": "US",
+            "sunrise": 1699960000,
+            "sunset": 1699996000,
+        },
+        "timezone": -18000,
+        "id": 5128581,
+        "name": "New York",
+        "cod": 200,
+    }
+
+
+@pytest.fixture
+def sample_parsed_weather_data():
+    """Dict matching the output of WeatherCollector.parse_weather_data()."""
+    return {
+        "city": "New York",
+        "country": "US",
+        "timestamp": datetime.fromtimestamp(1700000000),
+        "temperature": 22.5,
+        "feels_like": 21.8,
+        "temp_min": 20.0,
+        "temp_max": 25.0,
+        "pressure": 1013,
+        "humidity": 65,
+        "wind_speed": 3.5,
+        "wind_deg": 180,
+        "cloudiness": 10,
+        "weather_main": "Clear",
+        "weather_description": "clear sky",
+        "visibility": 10000,
+        "rain_1h": 0,
+        "snow_1h": 0,
+        "lat": 40.7143,
+        "lon": -74.006,
+        "timezone": -18000,
+    }
+
+
+@pytest.fixture
+def sample_weather_dataframe():
+    """50-row DataFrame with 2 cities x 25 hourly observations."""
+    np.random.seed(42)
+    cities = ["New York", "Los Angeles"]
+    rows_per_city = 25
+    rows = []
+    base_time = datetime(2024, 1, 1)
+
+    for city in cities:
+        base_temp = 22.0 if city == "New York" else 28.0
+        for i in range(rows_per_city):
+            rows.append(
+                {
+                    "city": city,
+                    "timestamp": base_time + timedelta(hours=i),
+                    "temperature": base_temp + np.random.normal(0, 3),
+                    "humidity": int(np.clip(65 + np.random.normal(0, 10), 0, 100)),
+                    "pressure": int(1013 + np.random.normal(0, 5)),
+                    "wind_speed": max(0, 3.5 + np.random.normal(0, 1.5)),
+                    "cloudiness": int(np.clip(np.random.uniform(0, 100), 0, 100)),
+                    "weather_main": np.random.choice(
+                        ["Clear", "Clouds", "Rain", "Snow"]
+                    ),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def weather_config(tmp_path):
+    """WeatherConfig instance pointing to a temporary database."""
+    return CollectorWeatherConfig(
+        api_key="fake_api_key_for_testing",
+        cities=["New York", "Los Angeles"],
+        db_path=str(tmp_path / "test_weather.db"),
+    )
+
+
+@pytest.fixture
+def mock_collector(weather_config, sample_raw_api_response):
+    """WeatherCollector with requests.get patched to return sample data."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = sample_raw_api_response
+    mock_response.raise_for_status.return_value = None
+
+    with patch(
+        "src.data_collection.weather_collector.requests.get",
+        return_value=mock_response,
+    ) as mock_get:
+        collector = WeatherCollector(weather_config)
+        yield collector, mock_get

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,62 @@
+"""
+Tests for weather API integration.
+Unit tests use mocks; integration tests hit the live API.
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from requests.exceptions import HTTPError, Timeout
+
+from src.data_collection.weather_collector import WeatherCollector, WeatherConfig
+
+
+class TestAPIUnit:
+    def test_fetch_weather_data_success(self, mock_collector):
+        collector, mock_get = mock_collector
+        result = collector.fetch_weather_data("New York")
+
+        assert result is not None
+        assert result["name"] == "New York"
+        assert result["main"]["temp"] == 22.5
+        mock_get.assert_called_once()
+
+    def test_fetch_weather_data_http_error(self, weather_config):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = HTTPError("404 Not Found")
+
+        with patch(
+            "src.data_collection.weather_collector.requests.get",
+            return_value=mock_response,
+        ):
+            collector = WeatherCollector(weather_config)
+            result = collector.fetch_weather_data("InvalidCity")
+
+        assert result is None
+
+    def test_fetch_weather_data_timeout(self, weather_config):
+        with patch(
+            "src.data_collection.weather_collector.requests.get",
+            side_effect=Timeout("Connection timed out"),
+        ):
+            collector = WeatherCollector(weather_config)
+            result = collector.fetch_weather_data("New York")
+
+        assert result is None
+
+
+@pytest.mark.integration
+class TestAPIIntegration:
+    def test_live_api_connection(self):
+        api_key = os.getenv("OPENWEATHER_API_KEY")
+        if not api_key:
+            pytest.skip("OPENWEATHER_API_KEY not set")
+
+        config = WeatherConfig(api_key=api_key, cities=["New York"])
+        collector = WeatherCollector(config)
+        data = collector.fetch_weather_data("New York")
+
+        assert data is not None
+        assert data["name"] == "New York"
+        assert "main" in data
+        assert "temp" in data["main"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+"""
+Tests for configs/config.py dataclasses.
+"""
+
+from configs.config import WeatherConfig, DatabaseConfig, ModelConfig
+
+
+class TestWeatherConfig:
+    def test_default_cities_populated(self):
+        config = WeatherConfig()
+        assert len(config.cities) == 10
+
+    def test_default_cities_includes_new_york(self):
+        config = WeatherConfig()
+        assert "New York" in config.cities
+
+    def test_custom_cities_preserved(self):
+        config = WeatherConfig(cities=["London", "Paris"])
+        assert config.cities == ["London", "Paris"]
+
+    def test_default_db_path(self):
+        config = WeatherConfig()
+        assert config.db_path == "data/weather.db"
+
+
+class TestDatabaseConfig:
+    def test_default_db_path(self):
+        config = DatabaseConfig()
+        assert config.db_path == "data/weather.db"
+
+    def test_default_backup_path(self):
+        config = DatabaseConfig()
+        assert config.backup_path == "data/backups/"
+
+
+class TestModelConfig:
+    def test_default_model_dir(self):
+        config = ModelConfig()
+        assert config.model_dir == "models/"
+
+    def test_default_random_state(self):
+        config = ModelConfig()
+        assert config.random_state == 42
+
+    def test_default_test_size(self):
+        config = ModelConfig()
+        assert config.test_size == 0.2

--- a/tests/test_data_collection.py
+++ b/tests/test_data_collection.py
@@ -1,0 +1,143 @@
+"""
+Tests for weather data collection, storage, and retrieval.
+Unit tests use mocks and tmp_path; integration tests use the live API.
+"""
+
+import os
+import sqlite3
+import pytest
+
+from src.data_collection.weather_collector import WeatherCollector, WeatherConfig
+
+
+class TestDatabaseSetup:
+    def test_database_file_created(self, weather_config):
+        WeatherCollector(weather_config)
+        assert os.path.exists(weather_config.db_path)
+
+    def test_weather_data_table_exists(self, weather_config):
+        WeatherCollector(weather_config)
+        conn = sqlite3.connect(weather_config.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables = [row[0] for row in cursor.fetchall()]
+        conn.close()
+        assert "weather_data" in tables
+
+    def test_required_columns_present(self, weather_config):
+        WeatherCollector(weather_config)
+        conn = sqlite3.connect(weather_config.db_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(weather_data);")
+        columns = [col[1] for col in cursor.fetchall()]
+        conn.close()
+
+        required = ["city", "temperature", "humidity", "pressure", "wind_speed"]
+        for col in required:
+            assert col in columns, f"Missing column: {col}"
+
+
+class TestParseWeatherData:
+    def test_all_expected_keys_present(self, weather_config, sample_raw_api_response):
+        collector = WeatherCollector(weather_config)
+        parsed = collector.parse_weather_data(sample_raw_api_response)
+
+        expected_keys = [
+            "city", "country", "timestamp", "temperature", "feels_like",
+            "temp_min", "temp_max", "pressure", "humidity", "wind_speed",
+            "wind_deg", "cloudiness", "weather_main", "weather_description",
+            "visibility", "rain_1h", "snow_1h", "lat", "lon", "timezone",
+        ]
+        for key in expected_keys:
+            assert key in parsed, f"Missing key: {key}"
+
+    def test_correct_values_extracted(self, weather_config, sample_raw_api_response):
+        collector = WeatherCollector(weather_config)
+        parsed = collector.parse_weather_data(sample_raw_api_response)
+
+        assert parsed["city"] == "New York"
+        assert parsed["country"] == "US"
+        assert parsed["temperature"] == 22.5
+        assert parsed["humidity"] == 65
+        assert parsed["pressure"] == 1013
+        assert parsed["wind_speed"] == 3.5
+        assert parsed["weather_main"] == "Clear"
+
+
+class TestStoreAndRetrieve:
+    def test_store_inserts_row(self, mock_collector, sample_raw_api_response):
+        collector, _ = mock_collector
+        parsed = collector.parse_weather_data(sample_raw_api_response)
+        collector.store_weather_data(parsed)
+
+        conn = sqlite3.connect(collector.config.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM weather_data")
+        count = cursor.fetchone()[0]
+        conn.close()
+
+        assert count == 1
+
+    def test_collect_all_cities_stores_one_per_city(self, mock_collector):
+        collector, _ = mock_collector
+        collector.collect_all_cities()
+
+        conn = sqlite3.connect(collector.config.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM weather_data")
+        count = cursor.fetchone()[0]
+        conn.close()
+
+        assert count == len(collector.config.cities)
+
+
+@pytest.mark.integration
+class TestDataCollectionIntegration:
+    def test_live_api_connection(self):
+        api_key = os.getenv("OPENWEATHER_API_KEY")
+        if not api_key:
+            pytest.skip("OPENWEATHER_API_KEY not set")
+
+        config = WeatherConfig(api_key=api_key, cities=["New York"])
+        collector = WeatherCollector(config)
+        data = collector.fetch_weather_data("New York")
+
+        assert data is not None
+        assert data["main"]["temp"] is not None
+
+    def test_live_database_setup(self, tmp_path):
+        config = WeatherConfig(
+            api_key="dummy_key",
+            cities=["New York"],
+            db_path=str(tmp_path / "live_test.db"),
+        )
+        collector = WeatherCollector(config)
+        assert os.path.exists(config.db_path)
+
+        conn = sqlite3.connect(config.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables = [row[0] for row in cursor.fetchall()]
+        conn.close()
+        assert "weather_data" in tables
+
+    def test_live_data_collection(self, tmp_path):
+        api_key = os.getenv("OPENWEATHER_API_KEY")
+        if not api_key:
+            pytest.skip("OPENWEATHER_API_KEY not set")
+
+        config = WeatherConfig(
+            api_key=api_key,
+            cities=["New York", "Los Angeles"],
+            db_path=str(tmp_path / "collect_test.db"),
+        )
+        collector = WeatherCollector(config)
+        collector.collect_all_cities()
+
+        conn = sqlite3.connect(config.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM weather_data")
+        count = cursor.fetchone()[0]
+        conn.close()
+
+        assert count >= 2


### PR DESCRIPTION
## Summary
- Add `pytest` and `pytest-cov` to `requirements.txt`
- Create `pytest.ini` with test discovery config, `--strict-markers`, and integration marker gating
- Add `tests/conftest.py` with 5 shared fixtures (sample API response, parsed data, DataFrame, config, mock collector)
- Add `tests/test_config.py` (9 tests) validating `WeatherConfig`, `DatabaseConfig`, and `ModelConfig` defaults
- Add `tests/test_api.py` (3 unit + 1 integration) testing fetch success, HTTP errors, and timeouts
- Add `tests/test_data_collection.py` (7 unit + 3 integration) testing DB setup, parsing, storage, and retrieval

## Test plan
- [x] `pytest` — 19 passed, 4 integration deselected
- [x] `pytest -m integration` — 1 passed, 3 skipped (no API key), 19 deselected
- [x] `pytest --cov=src --cov=configs` — coverage report works
- [x] `pytest --collect-only` — only `tests/` files discovered, root smoke tests excluded
- [x] `python -X utf8 test_data_collection.py` — root smoke test still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)