### PR TITLE
Add CI/CD workflows for testing, linting, and type checking

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,40 @@
+[flake8]
+max-line-length = 120
+ignore =
+    # Line length (handled by black)
+    E501,
+    # Whitespace before ':' (conflicts with black)
+    E203,
+    # Line break before binary operator (conflicts with black)
+    W503,
+    # Trailing whitespace
+    W291,
+    # Blank line contains whitespace
+    W293,
+    # No newline at end of file
+    W292,
+    # Line break after binary operator
+    W504,
+    # Missing whitespace around arithmetic operator
+    E226,
+    # Module level import not at top of file (needed for matplotlib.use)
+    E402,
+    # Continuation line indentation (conflicts with black)
+    E127,
+    E128,
+    # Expected 2 blank lines
+    E302,
+    E305,
+    # Unused imports (will be enforced incrementally)
+    F401,
+    # f-string without placeholders
+    F541,
+    # Assigned but unused variable
+    F841
+exclude =
+    .git,
+    __pycache__,
+    venv,
+    .venv,
+    build,
+    dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,72 @@
+name: Lint & Type Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-lint-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-lint-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Check formatting with black
+        continue-on-error: true
+        run: |
+          black --check --diff src/ configs/ tests/
+
+      - name: Lint with flake8
+        run: |
+          flake8 src/ configs/ tests/
+
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-typecheck-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-typecheck-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run mypy
+        continue-on-error: true
+        run: |
+          mypy src/ configs/ --ignore-missing-imports --no-strict-optional

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run unit tests with coverage
+        run: |
+          pytest --cov=src --cov=configs --cov-report=xml --cov-report=term-missing
+
+      - name: Run slow tests
+        run: |
+          pytest -m "slow" --no-header -q
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.10'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,8 @@ python-dotenv==1.0.0
 # Testing
 pytest==7.4.0
 pytest-cov==4.1.0
+
+# Linting & Type Checking
+black==23.7.0
+flake8==6.1.0
+mypy==1.5.1


### PR DESCRIPTION
- test.yml: Runs pytest across Python 3.9/3.10/3.11 with coverage reporting and Codecov upload on push/PR to main
- lint.yml: Runs black formatting check, flake8 linting, and mypy type checking (black/mypy as non-blocking until codebase conforms)
- .flake8: Project-wide flake8 configuration
- requirements.txt: Add black, flake8, mypy dependencies